### PR TITLE
Add repository URL to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ requires-python = ">=3.12,<4.0"
 dependencies = [
 ]
 
+[project.urls]
+repository = "https://github.com/pathunstrom/dykes"
+
 [tool.poetry]
 version = "0.0.0"
 


### PR DESCRIPTION
This should make a link to the GitHub repo show up on PyPi for future releases.