### PR TITLE
Expose Flags and NArgs at the top level.

### DIFF
--- a/src/dykes/__init__.py
+++ b/src/dykes/__init__.py
@@ -1,5 +1,5 @@
 from .processing import parse_args, build_parser
-from .options import Action, Count, StoreFalse, StoreTrue
+from .options import Action, Count, Flags, NArgs, StoreFalse, StoreTrue
 
 __all__ = [
     "options",
@@ -7,6 +7,8 @@ __all__ = [
     "build_parser",
     "Action",
     "Count",
+    "Flags",
+    "NArgs",
     "StoreFalse",
     "StoreTrue",
 ]

--- a/tests/test_simple_parser/test_dykes.py
+++ b/tests/test_simple_parser/test_dykes.py
@@ -1,0 +1,19 @@
+import pytest
+
+import dykes
+
+
+@pytest.mark.black_box
+def test_public_interface():
+    """
+    This test is just to catch changes to the public API.
+    """
+    assert dykes.options
+    assert dykes.parse_args
+    assert dykes.build_parser
+    assert dykes.Action
+    assert dykes.Count
+    assert dykes.Flags
+    assert dykes.NArgs
+    assert dykes.StoreFalse
+    assert dykes.StoreTrue

--- a/tests/test_simple_parser/test_processing/test_build_parser.py
+++ b/tests/test_simple_parser/test_processing/test_build_parser.py
@@ -1,5 +1,4 @@
 import argparse
-from bdb import bar
 from dataclasses import dataclass
 from typing import NamedTuple, Annotated
 
@@ -162,7 +161,7 @@ def test_multiple_position_with_default_raises_group():
     @dataclass
     class Application:
         boolean: dykes.StoreTrue  # No exception
-        foo: str = bar  # Exception
+        foo: str = "bar"  # Exception
         number: int = 7  # Exception
 
     with pytest.raises(


### PR DESCRIPTION
Got multiple folks surprised by moving to keeping options in options, so hoisting the rest of them into the dykes namespace.

Added our first black box test: Just want to make sure we don't unintentionally move things and break users code.