### PR TITLE
processing: Add prog= optional argument.

### DIFF
--- a/src/dykes/processing.py
+++ b/src/dykes/processing.py
@@ -36,6 +36,7 @@ def parse_args[ArgsType](
     *,
     args: list | None = None,
     development_mode: bool = False,
+    prog: str | None = None,
 ) -> ArgsType:
     """
     Process arguments and conform them to an input type.
@@ -83,15 +84,17 @@ def parse_args[ArgsType](
         dev_mode = True
     if args is None:
         args = sys.argv[1:]
-    parser = build_parser(application_struct)
+    parser = build_parser(application_struct, prog)
     parsed = parser.parse_args(args)
     return application_struct(**vars(parsed))
 
 
-def build_parser(application_definition: type) -> argparse.ArgumentParser:
+def build_parser(
+    application_definition: type, prog: str | None = None
+) -> argparse.ArgumentParser:
     exceptions = []
     description = getdoc(application_definition)
-    parser = argparse.ArgumentParser(description=description)
+    parser = argparse.ArgumentParser(description=description, prog=prog)
     fields = get_field_definitions(application_definition)
     parameters = generate_parameter_definitions(fields)
     for parameter in parameters:

--- a/tests/test_simple_parser/test_processing/test_parse_args.py
+++ b/tests/test_simple_parser/test_processing/test_parse_args.py
@@ -289,3 +289,15 @@ def test_explicit_union_with_none(inputs: list[str], expected: dict[str, str]):
     app = dykes.parse_args(App, args=inputs)
 
     assert app == App(**expected)
+
+
+def test_error_message_incldues_prog(capsys):
+    @dataclasses.dataclass
+    class Application:
+        argument: str
+
+    with pytest.raises(SystemExit):
+        dykes.parse_args(Application, args=[], prog="some_program_name")
+
+    captured = capsys.readouterr()
+    assert "some_program_name" in captured.err


### PR DESCRIPTION
This allows the error message to be customized, not hardcoded to use the default value based on argv[0].

I'm experimenting with using dykes as a part of a line-based TUI. The design gets a line with input(), splits it with shlex(), then calls a function with the resulting arguments which then do ad hoc operations to parse their arguments.

I am hoping that I can shift to using dykes and escape the ad-hoc parsing, but one of the problems I immediately ran into was that errors parsing the argument list would name the overall program, not the particular TUI command that was being parsed.